### PR TITLE
Imports: use new `golang.org` import paths.

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -108,7 +108,7 @@ type Context interface {
 	// 	// Package user defines a User type that's stored in Contexts.
 	// 	package user
 	//
-	// 	import "code.google.com/p/go.net/context"
+	// 	import "golang.org/x/net/context"
 	//
 	// 	// User is the type of value stored in the Contexts.
 	// 	type User struct {...}

--- a/context/withtimeout_test.go
+++ b/context/withtimeout_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"code.google.com/p/go.net/context"
+	"golang.org/x/net/context"
 )
 
 func ExampleWithTimeout() {

--- a/html/charset/charset.go
+++ b/html/charset/charset.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"code.google.com/p/go.net/html"
-	"code.google.com/p/go.text/encoding"
-	"code.google.com/p/go.text/encoding/charmap"
-	"code.google.com/p/go.text/transform"
+	"golang.org/x/net/html"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/transform"
 )
 
 // Lookup returns the encoding with the specified label, and its canonical

--- a/html/charset/charset_test.go
+++ b/html/charset/charset_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/go.text/transform"
+	"golang.org/x/text/transform"
 )
 
 func transformString(t transform.Transformer, s string) (string, error) {

--- a/html/charset/gen.go
+++ b/html/charset/gen.go
@@ -48,9 +48,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("import (")
-	fmt.Println(`"code.google.com/p/go.text/encoding"`)
+	fmt.Println(`"golang.org/x/text/encoding"`)
 	for _, pkg := range []string{"charmap", "japanese", "korean", "simplifiedchinese", "traditionalchinese", "unicode"} {
-		fmt.Printf("\"code.google.com/p/go.text/encoding/%s\"\n", pkg)
+		fmt.Printf("\"golang.org/x/text/encoding/%s\"\n", pkg)
 	}
 	fmt.Println(")")
 	fmt.Println()

--- a/html/charset/table.go
+++ b/html/charset/table.go
@@ -3,13 +3,13 @@
 package charset
 
 import (
-	"code.google.com/p/go.text/encoding"
-	"code.google.com/p/go.text/encoding/charmap"
-	"code.google.com/p/go.text/encoding/japanese"
-	"code.google.com/p/go.text/encoding/korean"
-	"code.google.com/p/go.text/encoding/simplifiedchinese"
-	"code.google.com/p/go.text/encoding/traditionalchinese"
-	"code.google.com/p/go.text/encoding/unicode"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
+	"golang.org/x/text/encoding/unicode"
 )
 
 var encodings = map[string]struct {

--- a/html/example_test.go
+++ b/html/example_test.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"strings"
 
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 )
 
 func ExampleParse() {

--- a/html/node.go
+++ b/html/node.go
@@ -5,7 +5,7 @@
 package html
 
 import (
-	"code.google.com/p/go.net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // A NodeType is the type of a Node.

--- a/html/parse.go
+++ b/html/parse.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"strings"
 
-	a "code.google.com/p/go.net/html/atom"
+	a "golang.org/x/net/html/atom"
 )
 
 // A parser implements the HTML5 parsing algorithm:

--- a/html/parse_test.go
+++ b/html/parse_test.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/go.net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // readParseTest reads a single test case from r.

--- a/html/testdata/go1.html
+++ b/html/testdata/go1.html
@@ -812,9 +812,9 @@ This table lists the old and new import paths:
 <tr>
 <td colspan="2"><hr></td>
 </tr>
-<tr><td>net/dict</td> <td>code.google.com/p/go.net/dict</tr>
-<tr><td>net/websocket</td> <td>code.google.com/p/go.net/websocket</tr>
-<tr><td>exp/spdy</td> <td>code.google.com/p/go.net/spdy</tr>
+<tr><td>net/dict</td> <td>golang.org/x/net/dict</tr>
+<tr><td>net/websocket</td> <td>golang.org/x/net/websocket</tr>
+<tr><td>exp/spdy</td> <td>golang.org/x/net/spdy</tr>
 <tr>
 <td colspan="2"><hr></td>
 </tr>

--- a/html/token.go
+++ b/html/token.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"code.google.com/p/go.net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // A TokenType is the type of a Token.

--- a/ipv4/multicastlistener_test.go
+++ b/ipv4/multicastlistener_test.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"testing"
 
-	"code.google.com/p/go.net/internal/nettest"
-	"code.google.com/p/go.net/ipv4"
+	"golang.org/x/net/internal/nettest"
+	"golang.org/x/net/ipv4"
 )
 
 var udpMultipleGroupListenerTests = []net.Addr{

--- a/ipv4/multicastsockopt_test.go
+++ b/ipv4/multicastsockopt_test.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"testing"
 
-	"code.google.com/p/go.net/internal/nettest"
-	"code.google.com/p/go.net/ipv4"
+	"golang.org/x/net/internal/nettest"
+	"golang.org/x/net/ipv4"
 )
 
 var packetConnMulticastSocketOptionTests = []struct {

--- a/ipv6/icmp_test.go
+++ b/ipv6/icmp_test.go
@@ -5,7 +5,7 @@
 package ipv6_test
 
 import (
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"os"
 	"reflect"

--- a/ipv6/mockicmp_test.go
+++ b/ipv6/mockicmp_test.go
@@ -5,7 +5,7 @@
 package ipv6_test
 
 import (
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"errors"
 	"net"
 )

--- a/ipv6/multicast_test.go
+++ b/ipv6/multicast_test.go
@@ -6,7 +6,7 @@ package ipv6_test
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"os"
 	"runtime"

--- a/ipv6/multicastlistener_test.go
+++ b/ipv6/multicastlistener_test.go
@@ -5,7 +5,7 @@
 package ipv6_test
 
 import (
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"fmt"
 	"net"
 	"os"

--- a/ipv6/multicastsockopt_test.go
+++ b/ipv6/multicastsockopt_test.go
@@ -5,7 +5,7 @@
 package ipv6_test
 
 import (
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"os"
 	"runtime"

--- a/ipv6/readwrite_test.go
+++ b/ipv6/readwrite_test.go
@@ -6,7 +6,7 @@ package ipv6_test
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"runtime"
 	"sync"

--- a/ipv6/sockopt_test.go
+++ b/ipv6/sockopt_test.go
@@ -5,7 +5,7 @@
 package ipv6_test
 
 import (
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"os"
 	"runtime"

--- a/ipv6/unicast_test.go
+++ b/ipv6/unicast_test.go
@@ -6,7 +6,7 @@ package ipv6_test
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"os"
 	"runtime"

--- a/ipv6/unicastsockopt_test.go
+++ b/ipv6/unicastsockopt_test.go
@@ -5,7 +5,7 @@
 package ipv6_test
 
 import (
-	"code.google.com/p/go.net/ipv6"
+	"golang.org/x/net/ipv6"
 	"net"
 	"os"
 	"runtime"

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -31,7 +31,7 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/go.net/idna"
+	"golang.org/x/net/idna"
 )
 
 const (

--- a/websocket/exampledial_test.go
+++ b/websocket/exampledial_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 // This example demonstrates a trivial client.

--- a/websocket/examplehandler_test.go
+++ b/websocket/examplehandler_test.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 // Echo the data received on the WebSocket.


### PR DESCRIPTION
code.google.com is not supported anymore, meaning that `go get` cannot
detect the VCS for the package.

This updates the import paths to use the new endpoints, specified
[here](https://groups.google.com/forum/#!topic/golang-announce/eD8dh3T9yyA)
