### PR TITLE
Support linux on arm64

### DIFF
--- a/ipv4/syscall_unix.go
+++ b/ipv4/syscall_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux,amd64 linux,arm netbsd openbsd
+// +build darwin dragonfly freebsd linux,amd64 linux,arm linux,arm64 netbsd openbsd
 
 package ipv4
 

--- a/ipv6/syscall_unix.go
+++ b/ipv6/syscall_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux,amd64 linux,arm netbsd openbsd
+// +build darwin dragonfly freebsd linux,amd64 linux,arm linux,arm64 netbsd openbsd
 
 package ipv6
 


### PR DESCRIPTION
Allow downstream projects to target linux_arm64.  arm64 needed to be
independently tagged in addition to arm.